### PR TITLE
Bug fixes and additional config options from encoderc4 provisioning from scratch

### DIFF
--- a/ansible/c4
+++ b/ansible/c4
@@ -1,0 +1,5 @@
+[c4]
+encoderc4.lan.c3voc.de ansible_ssh_host=encoderc4.labor.koeln.ccc.de
+
+[encoders]
+encoderc4.lan.c3voc.de crs_token="{{ lookup('keepass', 'ansible/worker-groups/encoderC4.username') }}" crs_secret="{{ lookup('keepass', 'ansible/worker-groups/encoderC4.password') }}"

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -183,6 +183,11 @@ users:
   - { name: 'mntl', state: 'present' }
   - { name: 'voc', state: 'present' }
 
+#used in encoders rc.local
+trusted_subnets:
+  "voc"    : "10.73.0.0/16"
+  "voc vpn": "10.8.0.0/16"
+
 additional_users: []
 
 distribution_mode: icedist

--- a/ansible/group_vars/c4
+++ b/ansible/group_vars/c4
@@ -1,0 +1,52 @@
+---
+room_number: 97
+room_fahrplan_name: C4
+
+#TODO: is this even still needed?
+grabbersource_url_path: stream.mjpg
+
+encodermode: hd-voctomix2
+
+# Anzahl der Stereo-Streams (1 = native, 2 = first translator, 3 = second translator, 4 = PA Backup)
+voctomix_audiostreams: 2
+voctomix_stream_suppress_audio_tracks: [1]
+
+voctomix_vaapi: true
+
+additional_users:
+    - { name: 'necro', state: 'present' }
+    - { name: 'nils', state: 'present' }
+    - { name: 'twix', state: 'present' }
+    - { name: 'yanosz', state: 'present' }
+
+voctomix_sources:
+  -
+    name: cam1
+    type: decklink-internal
+    devicenumber: 0
+    video_connection: SDI
+    video_mode: "1080i50"
+    volume: 1.0
+    deinterlace: "yes"
+    scan: interlaced
+    stream_names:
+        - original
+    audiostream:
+        0: "0+1"
+  -
+    name: slides
+    type: decklink-internal
+    devicenumber: 1
+    video_connection: HDMI
+    video_mode: "1080p60"
+
+voctomix_inverted_axis: true
+voctomix_shifted_sbs:   true
+
+blinder_audio:
+    original: "0+1"
+
+trusted_subnets:
+  "voc"    : "10.73.0.0/16"
+  "voc vpn": "10.8.0.0/16"
+  "c4"     : "172.23.22.0/23"

--- a/ansible/roles/common/tasks/user.yml
+++ b/ansible/roles/common/tasks/user.yml
@@ -55,7 +55,7 @@
     when: item.state != 'absent'
 
   - name: add user's authorized_keys
-    authorized_key: user="{{ item.name }}" manage_dir=true key="{{ lookup('keepass', 'ansible/authorized_keys/' + item.name + '.notes') }}"
+    authorized_key: user="{{ item.name }}" manage_dir=true key="{{ lookup('keepass', 'ansible/authorized_keys/' + item.name + '.notes', errors='warn') }}"
                     state=present exclusive=yes
     with_items: 
       - "{{ users }}"
@@ -63,7 +63,7 @@
     when: item.state != 'absent' and item.name != 'voc'
 
   - name: add user's authorized_keys to voc
-    authorized_key: user=voc manage_dir=true key="{{ lookup('keepass', 'ansible/authorized_keys/' + item.name + '.notes') }}"
+    authorized_key: user=voc manage_dir=true key="{{ lookup('keepass', 'ansible/authorized_keys/' + item.name + '.notes', errors='warn') }}"
                     state=present
     with_items:
       - "{{ users }}"

--- a/ansible/roles/encoder/tasks/general.yml
+++ b/ansible/roles/encoder/tasks/general.yml
@@ -17,7 +17,12 @@
   # Create common files and directories
   - name: create /video if not present
     file: dest=/video state=directory
-
+  
+  - name: create /etc/service if not present
+    file:
+      path: /etc/service
+      state: directory
+  
   - name: create common.sh
     copy: src=common.sh
           dest=/etc/service/common.sh

--- a/ansible/roles/encoder/tasks/packages.yml
+++ b/ansible/roles/encoder/tasks/packages.yml
@@ -6,6 +6,7 @@
     - libnginx-mod-rtmp
     - icecast2
     - samba
+#   - i965-va-driver-shaders
     - gstreamer1.0-plugins-bad
     - gstreamer1.0-plugins-base
     - gstreamer1.0-plugins-good

--- a/ansible/roles/encoder/tasks/packages.yml
+++ b/ansible/roles/encoder/tasks/packages.yml
@@ -6,7 +6,7 @@
     - libnginx-mod-rtmp
     - icecast2
     - samba
-#   - i965-va-driver-shaders
+    - i965-va-driver-shaders
     - gstreamer1.0-plugins-bad
     - gstreamer1.0-plugins-base
     - gstreamer1.0-plugins-good

--- a/ansible/roles/encoder/tasks/rsync.yml
+++ b/ansible/roles/encoder/tasks/rsync.yml
@@ -1,6 +1,6 @@
 ---
   - name: install rsync
-    apt: name=rsync state=installed
+    apt: name=rsync state=present
 
   - name: enable rsyncd
     lineinfile: dest=/etc/default/rsync
@@ -14,4 +14,4 @@
     notify: reload rsync config
 
   - name: enable rsyncd
-    service: name=rsync enabled=yes state=started
+    systemd: name=rsync enabled=yes state=started

--- a/ansible/roles/encoder/templates/rc.local/rc.local.encoder.j2
+++ b/ansible/roles/encoder/templates/rc.local/rc.local.encoder.j2
@@ -16,8 +16,9 @@ iptables -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 iptables -A INPUT -i lo -j ACCEPT
 
 # allow all from trusted ips
-iptables -A INPUT -s 10.73.0.0/16 -j ACCEPT -m comment --comment "voc subnet"
-iptables -A INPUT -s 10.8.0.0/16 -j ACCEPT -m comment --comment "voc vpn subnet"
+{% for name in trusted_subnets %}
+iptables -A INPUT -s {{trusted_subnets[name]}} -j ACCEPT -m comment --comment "{{name}} subnet"
+{% endfor %}
 
 # allow ssh
 iptables -A INPUT -p tcp --sport 1024:65535 --dport 22 -j ACCEPT

--- a/ansible/roles/encoder/templates/voctomix2-config/voctocore-config.ini.j2
+++ b/ansible/roles/encoder/templates/voctomix2-config/voctocore-config.ini.j2
@@ -124,8 +124,8 @@ pip.mirror              = true
 ; side-by-side (source A at left and B at right side)
 {% if voctomix_shifted_sbs is defined and voctomix_shifted_sbs %}
 {% if voctomix_inverted_axis is defined and voctomix_inverted_axis %}
-sbs.a                  = 0.008/0.42 0.49
-sbs.b                  = 0.503/0.08 0.49
+sbs.a                  = 0.503/0.08 0.49
+sbs.b                  = 0.008/0.42 0.49
 {% else %}
 sbs.a                  = 0.008/0.08 0.49
 sbs.b                  = 0.503/0.42 0.49

--- a/ansible/roles/encoder/templates/voctomix2-config/voctocore-config.ini.j2
+++ b/ansible/roles/encoder/templates/voctomix2-config/voctocore-config.ini.j2
@@ -122,27 +122,41 @@ pip.noswap              = true
 pip.mirror              = true
 
 ; side-by-side (source A at left and B at right side)
+{% if voctomix_shifted_sbs is defined and voctomix_shifted_sbs %}
+{% if voctomix_inverted_axis is defined and voctomix_inverted_axis %}
+sbs.a                  = 0.008/0.42 0.49
+sbs.b                  = 0.503/0.08 0.49
+{% else %}
+sbs.a                  = 0.008/0.08 0.49
+sbs.b                  = 0.503/0.42 0.49
+{% endif %}
+{% else %}
 sbs.a                   = 0.008/0.25 0.49
 sbs.b                   = 0.503/0.25 0.49
-
-; side-by-side-preview (source A bigger and B smaller and cropped beside)
-lec.a                  = 0.006/0.01 0.75
-lec.b                  = 0.60/0.42 0.56
-lec.crop-b             = 0.31/0
-lec.mirror             = true
-{% if voctomix_inverted_axis is not defined %}
-lec.mirror-initial     = true
 {% endif %}
 
 ; side-by-side-preview (source A bigger and B smaller and cropped beside)
+{% if voctomix_inverted_axis is defined and voctomix_inverted_axis %}
+lec.a                  = 0.244/0.01 0.75
+lec.b                  = -0.16/0.42 0.56
+{% else %}
+lec.a                  = 0.006/0.01 0.75
+lec.b                  = 0.60/0.42 0.56
+{% endif %}
+lec.crop-b             = 0.31/0
+lec.mirror             = true
+
+; side-by-side-preview (source A bigger and B smaller and cropped beside)
+{% if voctomix_inverted_axis is defined and voctomix_inverted_axis %}
+lec_43.a               = 0.125/0.0 1.0
+lec_43.b               = -0.16/0.42 0.56
+{% else %}
 lec_43.a               = -0.125/0.0 1.0
 lec_43.b               = 0.60/0.42 0.56
+{% endif %}
 lec_43.crop-a          = 0.125/0
 lec_43.crop-b          = 0.31/0
 lec_43.mirror          = true
-{% if voctomix_inverted_axis is not defined %}
-lec_43.mirror-initial  = true
-{% endif %}
 
 ; fullscreen source B (overlapping A)
 fs-b.a                  = *

--- a/ansible/roles/media-app/tasks/rails-app.yml
+++ b/ansible/roles/media-app/tasks/rails-app.yml
@@ -4,9 +4,10 @@
     user: media
     manage_dir: true
     state: present
-    key: "{{ lookup('keepass', 'ansible/authorized_keys/' + item.name + '.notes') }}"
+    key: "{{ lookup('keepass', 'ansible/authorized_keys/' + item.name + '.notes', errors='warn') }}"
   with_items:
     - "{{ users }}"
+    - "{{ additional_users }}"
   when: item.state != 'absent' and item.name != 'voc'
 
 - file: path=/srv/media/media-site/shared/config state=directory


### PR DESCRIPTION
This fixes a few problems while provisioning an encoder from a fresh debian buster.
It also makes some changes in order to make this playbook easier to pick up for assemblies or other users than the C3VOC in general:
- make play not fail when a user without a keepass key is specified, display a warning instead, this way assemblies can simply use the `additonal_users` variable to define users in there `host_vars` / `group_vars` so the divergence from master is lower
- made rc.local trusted ips configurable using the variable `trusted_subnets`

This also fixes the `voctomix_inverted_axis` options which was broken because the `mirror_initial` option was removed from voctomix2.
Also a voctomix_shifted_sbs option was added shifting the sources in the side-by-side composite in such a way that the logo is still shown (also respects voctomix_inverted_axis).

