### PR TITLE
bw: add package terminus and grub kernel cmdline option to use it

### DIFF
--- a/bundlewrap/bundles/apt/metadata.py
+++ b/bundlewrap/bundles/apt/metadata.py
@@ -52,6 +52,7 @@ defaults = {
             'strace': {},
             'systemd': {},
             'tcpdump': {},
+            'terminus': {},
             'tmux': {},
             'tree': {},
             'unzip': {},

--- a/bundlewrap/bundles/grub/metadata.py
+++ b/bundlewrap/bundles/grub/metadata.py
@@ -9,6 +9,7 @@ defaults = {
             'console': 'tty0',
             'consoleblank': '0',
             'elevator': 'deadline',
+            'fbcon': 'font:ter-132n,scrollback:128k',
             'net.ifnames': '0',
         },
     },


### PR DESCRIPTION
this commit sets a much larger font on the framebuffer console to make it easier to read on the 4k screens of the mixer laptops when f.ex debugging the core over ssh

see https://www.kernel.org/doc/Documentation/fb/fbcon.txt C1 and C2 for fbcon