### PR TITLE
bw/bundles/openssh: Refactor password auth to support multiple IP ranges

### DIFF
--- a/bundlewrap/bundles/openssh/files/sshd_config
+++ b/bundlewrap/bundles/openssh/files/sshd_config
@@ -33,11 +33,11 @@ MaxSessions 512
 MaxStartups 512:30:768
 
 Subsystem sftp internal-sftp
-% if allow_password_auth_for_voc_range:
+% for address in allow_password_auth_for_addresses:
 
-Match Address 10.73.0.0/16
+Match Address ${address}
     PasswordAuthentication yes
-% endif
+% endfor
 
 Match Group sftp
     ChrootDirectory %h

--- a/bundlewrap/bundles/openssh/items.py
+++ b/bundlewrap/bundles/openssh/items.py
@@ -13,7 +13,7 @@ files = {
         'context': {
             'login_users': login_users,
             'admin_users': users_from_metadata,
-            'allow_password_auth_for_voc_range': node.metadata.get('openssh/allow_password_auth_for_voc_range', True),
+            'allow_password_auth_for_addresses': node.metadata.get('openssh/allow_password_auth_for_addresses', ['10.73.0.0/16']),
         },
         'triggers': {
             'action:sshd_check_config',


### PR DESCRIPTION
If the encoder is located in a different network than the VOC IP range, it may be useful to also allow password-based login for the other RFC1918 networks.

~Otherwise/ additionally it would be nice to have an option to allow the network of the device's static IP. So e.g. 192.168.42.0/24 if the device has 192.168.42.3. But how to decide which is the right interface to take the IP-(range) from?~

So `allow_password_auth_for_voc_range` was replaced by `allow_password_auth_for_addresses` holding an array of IP address (ranges) as expected by the openSSH "Match Address" directive. The default value is still the VOC range, but users can override that (e.g. to an empty array to disable password auth all together) or to add more IP ranges or even individual addresses.