### PR TITLE
bw/bundels/users: Support user-specific shell and groups

### DIFF
--- a/bundlewrap/bundles/users/metadata.py
+++ b/bundlewrap/bundles/users/metadata.py
@@ -8,6 +8,8 @@ defaults = {
     'apt': {
         'packages': {
             'vim': {},
+            'bash': {},
+            'zsh': {},
         },
     },
     'users': {
@@ -67,6 +69,10 @@ def add_users_from_toml(metadata):
 
             if USERS_TOML[uname].get('ssh_pubkeys', set()):
                 users[uname]['ssh_pubkeys'] = set(USERS_TOML[uname]['ssh_pubkeys'])
+            if USERS_TOML[uname].get('shell', set()):
+                users[uname]['shell'] = USERS_TOML[uname]['shell']
+            if USERS_TOML[uname].get('groups', set()):
+                users[uname]['groups'] = set(USERS_TOML[uname]['groups'])
         elif uid is None:
             raise BundleError(f'{node.name}: user {uname} has no uid set, please set one manually')
         elif int(uid) < 2000:

--- a/users.toml
+++ b/users.toml
@@ -178,6 +178,8 @@ ssh_pubkeys = [
 enable_rz = true
 enable_event = true
 uid = 1122
+shell = "/bin/zsh"
+groups = ["video", "audio"]
 ssh_pubkeys = [
   "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILfSpvbTzaZLIF1xj8h2VFNZ/tNA+1Iotu2uu6F3DUQ9",
 ]


### PR DESCRIPTION
The "users" bundle supports user-specific shell and groups, but the values aren't imported from the users.toml.

This still needs to be tested on a machine and I don't know if this breaks the NixOS part. But I hope that Nix ignores additional parameters in the TOML tables.