### PR TITLE
Fix tests

### DIFF
--- a/bundlewrap/bundles/voctomix2/metadata.py
+++ b/bundlewrap/bundles/voctomix2/metadata.py
@@ -37,7 +37,7 @@ if node.os_version[0] in DEBIAN_TO_VOCTOMIX_VERSION:
     'voctomix2/version_tuple',
 )
 def voctomix_version(metadata):
-    rev = metadata.get('voctomix2/rev')
+    rev = metadata.get('voctomix2/rev', 'main')
 
     if '.' in rev:
         rev = rev.split('-')[0]  # remove pre-release suffixes

--- a/bundlewrap/bundles/voctomix2/metadata.py
+++ b/bundlewrap/bundles/voctomix2/metadata.py
@@ -40,6 +40,7 @@ def voctomix_version(metadata):
     rev = metadata.get('voctomix2/rev')
 
     if '.' in rev:
+        rev = rev.split('-')[0]  # remove pre-release suffixes
         version = tuple([int(i) for i in rev.split('.')])
     elif rev == 'voctomix2':
         version = (2,)


### PR DESCRIPTION
`bw test` was failing because of 2 issues:
- Version number detection was broken for pre-releases like `2.0-rc1`
- no voctomix version was available for nodes without Debian release specified